### PR TITLE
fix: fix timeout conflict

### DIFF
--- a/lib/invoker.js
+++ b/lib/invoker.js
@@ -44,8 +44,11 @@ class Invoker {
   destroy() {
     for (const promises of this._promiseMap.values()) {
       Object.keys(promises).forEach(seq => {
+        if (!promises || !promises[seq]) {
+          return;
+        }
         const { reject } = promises[seq];
-        delete promises[seq];
+        promises[seq] = undefined;
         reject(Error('rejected by destroy()'));
       });
     }
@@ -64,7 +67,7 @@ class Invoker {
     }
     const { reject } = promises[seq];
 
-    delete promises[seq];
+    promises[seq] = undefined;
 
     reject(Error(`method "${name}" timeout`));
   }
@@ -89,7 +92,7 @@ class Invoker {
 
     const { resolve, reject } = promises[_seq];
 
-    delete promises[_seq];
+    promises[_seq] = undefined;
 
     if (_status < 1) {
       resolve(payload);

--- a/test/caller.test.js
+++ b/test/caller.test.js
@@ -105,3 +105,14 @@ test('_onTimeout() with no promises should do nothing', () => {
   expect(invoker._onTimeout()).toBe(undefined);
   invoker.destroy();
 });
+
+test('fix _seq conflict to avoid timeout', async (callback) => {
+  const invoker = new Invoker(child_process.fork(fooScript));
+  setTimeout(async ()=>{
+    invoker.invoke('longTask');
+  }, 0);
+  setTimeout(async ()=>{
+    expect(invoker.invoke('longTask')).resolves.not.toThrow();
+    callback();
+  }, 2500);
+});

--- a/test/channel.test.js
+++ b/test/channel.test.js
@@ -112,15 +112,16 @@ test('destroy() should be ok', async () => {
   expect(() => invoker.destroy()).not.toThrow();
 });
 
-test('destroy() should be ok without disconnecting channel', async () => {
+test('destroy() should be ok without disconnecting channel', async (done) => {
   const channel = new InvokerChannel(fooScript);
   channel.disconnect = undefined;
   const invoker = new Invoker(channel);
   await invoker.invoke('foo');
   expect(() => invoker.destroy()).not.toThrow();
+  done();
 });
 
-test('destroy() should reject unconsumed promises', async () => {
+test('destroy() should reject unconsumed promises', async (done) => {
   const invoker = new Invoker(new InvokerChannel(fooScript));
   const promise = invoker.invoke('foo');
   invoker.destroy();
@@ -128,6 +129,7 @@ test('destroy() should reject unconsumed promises', async () => {
     await promise;
   } catch (err) {
     expect(err.message).toMatch('rejected by destroy()');
+    done();
   }
 });
 


### PR DESCRIPTION
当前一个同名任务结束时,下一个任务会被错误的当做超时退出.
原因是用于处理超时的 timer 未被清除,只是简单地通过 if 判断提前退出.